### PR TITLE
Add Edison bulb style clock program

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Edison Clock
+
+This repository contains a small Python script that prints the current time
+using an Edison bulb style font. The program relies on the `pyfiglet` library
+and uses the `bulbhead` font to mimic a vintage bulb display.
+
+## Requirements
+
+- Python 3
+- `pyfiglet` Python package
+
+Install `pyfiglet` with pip if necessary:
+
+```bash
+pip install pyfiglet
+```
+
+## Usage
+
+Run the script from the command line:
+
+```bash
+python3 edison_clock.py
+```
+
+The output will show the current time in large, bulb-styled letters.

--- a/edison_clock.py
+++ b/edison_clock.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+import pyfiglet
+
+
+def display_time():
+    """Display the current time in a style reminiscent of Edison bulbs."""
+    now = datetime.now()
+    # Format time as HH:MM:SS
+    time_str = now.strftime('%H:%M:%S')
+    # Render using the 'bulbhead' font which resembles vintage bulb lettering
+    art = pyfiglet.figlet_format(time_str, font='bulbhead')
+    print(art)
+
+
+if __name__ == '__main__':
+    display_time()


### PR DESCRIPTION
## Summary
- add a simple `edison_clock.py` program to display the current time using the `bulbhead` font from `pyfiglet`
- document usage and requirements in `README.md`

## Testing
- `python3 edison_clock.py`

------
https://chatgpt.com/codex/tasks/task_e_6882af3429a883269a89a0fc183e8159