### PR TITLE
Add pyfiglet import guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This repository contains a small Python script that prints the current time
 using an Edison bulb style font. The program relies on the `pyfiglet` library
-and uses the `bulbhead` font to mimic a vintage bulb display.
+and uses the `bulbhead` font to mimic a vintage bulb display. If `pyfiglet`
+is not installed, the script exits with a helpful message explaining how to
+install it.
 
 ## Requirements
 

--- a/edison_clock.py
+++ b/edison_clock.py
@@ -1,5 +1,11 @@
 from datetime import datetime
-import pyfiglet
+
+try:
+    import pyfiglet
+except ImportError as e:  # pragma: no cover - simple import guard
+    raise SystemExit(
+        "pyfiglet is required to run this program.\n" "Install it with 'pip install pyfiglet'."
+    ) from e
 
 
 def display_time():


### PR DESCRIPTION
## Summary
- add a try/except wrapper so `edison_clock.py` prints a helpful error if `pyfiglet` is missing
- document missing dependency message in the README

## Testing
- `python3 -m py_compile edison_clock.py`
- `python3 edison_clock.py` *(fails: `pyfiglet` module not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6882acf97f6c83269f8c298746b38614