### PR TITLE
Add Asset Suite 9 document checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,28 @@ python3 edison_clock.py
 ```
 
 The output will show the current time in large, bulb-styled letters.
+
+## Checking Asset Suite 9 Documents
+
+The repository also includes a utility to validate document IDs against an Asset Suite 9 instance using a list stored in an Excel file.
+
+### Additional Requirements
+
+- `openpyxl`
+- `requests`
+
+Install these packages if they are not available:
+
+```bash
+pip install openpyxl requests
+```
+
+### Usage
+
+Provide the Excel file (document IDs in column A) and the API credentials for your Asset Suite 9 deployment:
+
+```bash
+python3 check_documents.py documents.xlsx --url <AS9_API_URL> --key <AS9_API_KEY> -o results.xlsx
+```
+
+The script will write a second column indicating whether each document was found ("FOUND" or "MISSING").

--- a/check_documents.py
+++ b/check_documents.py
@@ -1,0 +1,79 @@
+import os
+import openpyxl
+import requests
+
+
+def check_document(document_id, base_url, api_key):
+    """Query Asset Suite 9 for the given document ID.
+
+    Parameters
+    ----------
+    document_id : str
+        ID or name of the document to look up.
+    base_url : str
+        Base URL for the Asset Suite 9 API. Something like
+        ``https://example.com/api``.
+    api_key : str
+        API key or token used for authorization.
+    Returns
+    -------
+    bool
+        True if the document exists, False if not found.
+    """
+    url = f"{base_url}/documents/{document_id}"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+    }
+    response = requests.get(url, headers=headers)
+    if response.status_code == 200:
+        return True
+    elif response.status_code == 404:
+        return False
+    else:
+        response.raise_for_status()
+        return False
+
+
+def process_excel(in_path, out_path, base_url, api_key):
+    """Read document IDs from the Excel file and check each one."""
+    wb = openpyxl.load_workbook(in_path)
+    sheet = wb.active
+
+    # Assume first column contains document IDs
+    for row in sheet.iter_rows(min_row=2):
+        cell = row[0]
+        doc_id = str(cell.value).strip() if cell.value is not None else ""
+        if not doc_id:
+            continue
+        try:
+            exists = check_document(doc_id, base_url, api_key)
+            result = "FOUND" if exists else "MISSING"
+        except Exception as exc:
+            result = f"ERROR: {exc}"
+        # Write result to second column
+        sheet.cell(row=cell.row, column=2, value=result)
+
+    wb.save(out_path)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Check Asset Suite 9 documents from Excel list")
+    parser.add_argument("excel", help="Path to the Excel file containing document IDs in column A")
+    parser.add_argument("-o", "--output", default="results.xlsx", help="Output Excel file with results")
+    parser.add_argument("--url", default=os.environ.get("AS9_URL", ""), help="Base URL for Asset Suite 9 API")
+    parser.add_argument("--key", default=os.environ.get("AS9_KEY", ""), help="API key or token for Asset Suite 9")
+
+    args = parser.parse_args()
+
+    if not args.url or not args.key:
+        parser.error("API URL and key must be provided via arguments or environment variables")
+
+    process_excel(args.excel, args.output, args.url, args.key)
+    print(f"Results written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `check_documents.py` for verifying document IDs in Asset Suite 9 using an Excel list
- document new utility in README

## Testing
- `python3 -m py_compile edison_clock.py check_documents.py`


------
https://chatgpt.com/codex/tasks/task_e_6882d6d95dc883269bff6fb3472688e5