### PR TITLE
Add rainbow Edison bulb clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # Edison Clock
 
-This repository contains a small Python script that prints the current time
-using an Edison bulb style font. The program relies on the `pyfiglet` library
-and uses the `bulbhead` font to mimic a vintage bulb display.
+This repository contains a small Python script that prints the current time in
+an Edison bulb style ASCII art. Each digit appears in a different color that
+cascades like a rainbow and refreshes every second. The program relies on the
+`pyfiglet` and `colorama` libraries for the styled, colored output.
 
 ## Requirements
 
 - Python 3
 - `pyfiglet` Python package
+- `colorama` Python package
 
-Install `pyfiglet` with pip if necessary:
+Install the required packages with pip if necessary:
 
 ```bash
-pip install pyfiglet
+pip install pyfiglet colorama
 ```
 
 ## Usage
@@ -23,4 +25,6 @@ Run the script from the command line:
 python3 edison_clock.py
 ```
 
-The output will show the current time in large, bulb-styled letters.
+The output will show the current time in large bulb-styled letters that update
+every second. The digits cycle through rainbow colors as the clock refreshes.
+Press `Ctrl+C` to exit.

--- a/edison_clock.py
+++ b/edison_clock.py
@@ -1,15 +1,50 @@
 from datetime import datetime
+import time
+
 import pyfiglet
+from colorama import Fore, Style, init
 
 
 def display_time():
-    """Display the current time in a style reminiscent of Edison bulbs."""
-    now = datetime.now()
-    # Format time as HH:MM:SS
-    time_str = now.strftime('%H:%M:%S')
-    # Render using the 'bulbhead' font which resembles vintage bulb lettering
-    art = pyfiglet.figlet_format(time_str, font='bulbhead')
-    print(art)
+    """Show an updating time display in a colored Edison bulb style."""
+    init(autoreset=True)
+
+    colors = [
+        Fore.RED,
+        Fore.YELLOW,
+        Fore.GREEN,
+        Fore.CYAN,
+        Fore.BLUE,
+        Fore.MAGENTA,
+    ]
+    shift = 0
+
+    try:
+        while True:
+            now = datetime.now()
+            time_str = now.strftime('%H:%M:%S')
+
+            char_lines = [
+                pyfiglet.figlet_format(ch, font="bulbhead").rstrip().split("\n")
+                for ch in time_str
+            ]
+            height = len(char_lines[0])
+            lines = []
+            for row in range(height):
+                line = ""
+                for idx, art in enumerate(char_lines):
+                    color = colors[(idx + shift) % len(colors)]
+                    line += color + art[row] + Style.RESET_ALL
+                lines.append(line)
+
+            print("\033[H\033[J", end="")  # Clear screen
+            print("\n".join(lines), flush=True)
+
+            shift = (shift + 1) % len(colors)
+            time.sleep(1)
+    except KeyboardInterrupt:
+        # Move to a new line on exit for clean terminal
+        print()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- show time in Edison bulb ASCII art with cascading rainbow colors
- refresh the display every second without scrolling
- document dependencies and rainbow clock behaviour in README

## Testing
- `python3 -m py_compile edison_clock.py`


------
https://chatgpt.com/codex/tasks/task_e_6882e19431388326a2265fa5544c4830