### PR TITLE
Add rainbow Edison bulb clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Edison Clock
 
-This repository contains a small Python script that prints the current time
-using an Edison bulb style font. The program relies on the `pyfiglet` library
-and uses the `bulbhead` font to mimic a vintage bulb display.
+This repository contains a small Python script that prints the current time in
+a colorful Edison bulb style. The display updates every second and shows a
+rainbow cascade across the digits.
 
 ## Requirements
 
 - Python 3
-- `pyfiglet` Python package
+- `pyfiglet` and `colorama` Python packages
 
-Install `pyfiglet` with pip if necessary:
+Install the required packages with pip if necessary:
 
 ```bash
-pip install pyfiglet
+pip install pyfiglet colorama
 ```
 
 ## Usage
@@ -23,4 +23,5 @@ Run the script from the command line:
 python3 edison_clock.py
 ```
 
-The output will show the current time in large, bulb-styled letters.
+The output will show the current time in a rainbow-colored bulbhead font. The
+display refreshes in place every second. Press `Ctrl+C` to exit.

--- a/edison_clock.py
+++ b/edison_clock.py
@@ -1,15 +1,49 @@
 from datetime import datetime
+import time
+
+from colorama import Fore, Style, init
 import pyfiglet
+
+COLORS = [
+    Fore.RED,
+    Fore.YELLOW,
+    Fore.GREEN,
+    Fore.CYAN,
+    Fore.BLUE,
+    Fore.MAGENTA,
+]
+
+
+def render_colored_time(time_str: str, offset: int) -> str:
+    """Return the bulb-style time string with cascading rainbow colors."""
+    fig = pyfiglet.Figlet(font="bulbhead")
+    char_art = [fig.renderText(ch).splitlines() for ch in time_str]
+    height = len(char_art[0])
+    lines = []
+    for row in range(height):
+        parts = []
+        for i, art_lines in enumerate(char_art):
+            color = COLORS[(i + offset) % len(COLORS)]
+            parts.append(color + art_lines[row] + Style.RESET_ALL)
+        lines.append("".join(parts))
+    return "\n".join(lines)
 
 
 def display_time():
-    """Display the current time in a style reminiscent of Edison bulbs."""
-    now = datetime.now()
-    # Format time as HH:MM:SS
-    time_str = now.strftime('%H:%M:%S')
-    # Render using the 'bulbhead' font which resembles vintage bulb lettering
-    art = pyfiglet.figlet_format(time_str, font='bulbhead')
-    print(art)
+    """Display the current time in a rainbow Edison bulb style."""
+    init(autoreset=True)
+    offset = 0
+
+    try:
+        while True:
+            now = datetime.now()
+            time_str = now.strftime("%H:%M:%S")
+            art = render_colored_time(time_str, offset)
+            print("\033[H\033[J" + art, end="", flush=True)
+            time.sleep(1)
+            offset = (offset + 1) % len(COLORS)
+    except KeyboardInterrupt:
+        print()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add rainbow-colored Edison bulb style clock
- refresh display every second in place
- update README with new description and dependencies

## Testing
- `python3 -m py_compile edison_clock.py`
- manual run of `python3 edison_clock.py` for a few seconds

------
https://chatgpt.com/codex/tasks/task_e_6882e19431388326a2265fa5544c4830